### PR TITLE
Adjust how to read credentials

### DIFF
--- a/tap_google_analytics/tap.py
+++ b/tap_google_analytics/tap.py
@@ -123,14 +123,15 @@ class TapGoogleAnalytics(Tap):
     ).to_dict()
 
     def _initialize_credentials(self):
-        if self.config.get("oauth_credentials"):
+        if self.config.get("client_id") and self.config.get("client_secret") and self.config.get("refresh_token"):
             return OAuthCredentials.from_authorized_user_info(
                 {
-                    "client_id": self.config["oauth_credentials"]["client_id"],
-                    "client_secret": self.config["oauth_credentials"]["client_secret"],
-                    "refresh_token": self.config["oauth_credentials"]["refresh_token"],
+                    "client_id": self.config["client_id"],
+                    "client_secret": self.config["client_secret"],
+                    "refresh_token": self.config["refresh_token"],
                 }
             )
+
 
         if self.config.get("key_file_location"):
             with open(self.config["key_file_location"]) as f:  # noqa: PTH123


### PR DESCRIPTION
Meltano Tap doesn't support OAuth in a way that will work with Hotglue. When tenants authenticate via the widget, the `client_id` , `client_secret` , and `refresh_token`  are set as top level fields in the config, not nested with an `oauth_credentials`  object.
The meltano tap that we forked is expecting those fields nested in the `oauth_credentials` object.